### PR TITLE
Move serializer to require dev, add Doctrine bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
         "symfony/expression-language": "^5.4 || ^6.2",
         "symfony/http-kernel": "^5.4 || ^6.2",
         "symfony/property-access": "^5.4 || ^6.2",
-        "symfony/routing": "^5.4 || ^6.2",
-        "symfony/serializer": "^5.4 || ^6.2"
+        "symfony/routing": "^5.4 || ^6.2"
     },
     "require-dev": {
         "symfony/framework-bundle": "^5.4 || ^6.2",
-        "symfony/phpunit-bridge": "^6.2"
+        "symfony/phpunit-bridge": "^6.2",
+        "symfony/serializer": "^5.4 || ^6.2"
     },
     "scripts": {
         "test": "simple-phpunit"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": ">=8.1",
         "doctrine/annotations": "^1.13",
+        "doctrine/doctrine-bundle": "^2.1",
         "doctrine/orm": "^2.8",
         "symfony/config": "^5.4 || ^6.2",
         "symfony/console": "^5.4 || ^6.2",


### PR DESCRIPTION
The Serializer component is only used in tests, also the `doctrine.orm.entity_manager` service, which is registered in doctrine bundle, is required.